### PR TITLE
Remove arrow buttons

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -8,3 +8,4 @@
 @import "address_autocomplete";
 @import "favourites";
 @import "scroll.css";
+@import "no_spinners";

--- a/app/assets/stylesheets/components/_no_spinners.scss
+++ b/app/assets/stylesheets/components/_no_spinners.scss
@@ -1,0 +1,9 @@
+/* Hide spinners for form inputs with the class 'no-spinners' */
+.no-spinners {
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+  }
+}

--- a/app/views/houses/_form.html.erb
+++ b/app/views/houses/_form.html.erb
@@ -7,10 +7,10 @@
     %>
     <!-- Hidden input for region which gets autofilled -->
     <%= f.input :region, input_html: { value: @extracted_region_name, readonly: true, class: 'greyed-out' } %>
-    <%= f.input :price, placeholder: "Price" %>
+    <%= f.input :price, as: :text, placeholder: "Price" %>
     <%= f.input :bedroom, placeholder: "bedroom" , collection: House::BEDROOM %>
     <%= f.input :bathroom, placeholder: "bathroom" , collection: House::BATHROOM %>
-    <%= f.input :square_feet, placeholder: "square feet?" %>
+    <%= f.input :square_feet, as: :text, placeholder: "square feet?" %>
     <%= f.input :description, placeholder: "describe this place" %>
     <%= f.input :property_type, placeholder: "property type", collection: House::PROPERTY_TYPE %>
     <%= f.input :tenure, placeholder: "how many years tenure", collection: House::TENURE_CAT  %>

--- a/app/views/houses/show.html.erb
+++ b/app/views/houses/show.html.erb
@@ -106,7 +106,7 @@
                         </div>
                         <div class="modal-body">
                           <%= simple_form_for [@house, offer] do |f| %>
-                            <%= f.input :price, error: offer.errors[:price], class: "form-control" %>
+                            <%= f.input :price, error: offer.errors[:price], class: "form-control no-spinners" %>
                         </div>
                         <div class="modal-footer">
                           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/app/views/houses/show.html.erb
+++ b/app/views/houses/show.html.erb
@@ -82,7 +82,7 @@
         <% if current_user != @house.user && !house_has_offer_by_current_user && @house.offers.where(status: 'accepted').length < 1  %>
           <h2>Submit an Offer</h2>
           <%= simple_form_for [@house, @offer] do |f| %>
-            <%= f.input :price, error: @offer.errors[:price], class: "form-control" %>
+            <%= f.input :price, as: :text, error: @offer.errors[:price], class: "form-control" %>
             <%= f.submit "Submit Offer", class: "btn btn-primary" %>
           <% end %>
         <% end %>


### PR DESCRIPTION
Converted input boxes in offers and new listing page to be text boxes, without the arrows at the right side of the boxes